### PR TITLE
Support FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/badboy/zeitstempel"
 cfg-if = "1.0.0"
 once_cell = "1.5.2"
 
-[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios", target_os = "freebsd"))'.dependencies]
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ We support the following operating systems:
 * Linux
 * Android
 * iOS
+* FreeBSD
 
 For other operating systems there's a fallback to `std::time::Instant`,
 compared against a process-global fixed reference point.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@
 //! * Linux
 //! * Android
 //! * iOS
+//! * FreeBSD
 //!
 //! For other operating systems there's a fallback to `std::time::Instant`,
 //! compared against a process-global fixed reference point.
@@ -70,9 +71,9 @@ cfg_if::cfg_if! {
     if #[cfg(any(target_os = "macos", target_os = "ios"))] {
         mod mac;
         use mac as sys;
-    } else if #[cfg(any(target_os = "linux", target_os = "android"))] {
-        mod linux;
-        use linux as sys;
+    } else if #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))] {
+        mod unix;
+        use unix as sys;
     } else if #[cfg(all(windows, feature = "win10plus"))] {
         mod win10;
         use win10 as sys;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -27,16 +27,21 @@ pub fn now_including_suspend() -> u64 {
 /// and represents monotonic time since some unspecified starting point,
 /// but that does not increment while the system is asleep.
 ///
-/// See [`clock_gettime`].
+/// See [`clock_gettime`] and [`FreeBSD clock_gettime`].
 ///
 /// [`clock_gettime`]: https://manpages.debian.org/buster/manpages-dev/clock_gettime.3.en.html
+/// [`FreeBSD clock_gettime`]: https://man.freebsd.org/cgi/man.cgi?query=clock_gettime&manpath=FreeBSD+15.0-RELEASE
 pub fn now_awake() -> u64 {
     let mut ts = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,
     };
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    let clock = libc::CLOCK_MONOTONIC;
+    #[cfg(target_os = "freebsd")]
+    let clock = libc::CLOCK_UPTIME;
     unsafe {
-        libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
+        libc::clock_gettime(clock, &mut ts);
     }
 
     timespec_to_ns(ts)


### PR DESCRIPTION
FreeBSD can use mostly the same implementation as Linux. The only difference is that instead of `CLOCK_MONOTONIC` (which is equivalent to `CLOCK_BOOTTIME` on FreeBSD), `now_awake()` uses `CLOCK_UPTIME`.

Rename linux.rs to unix.rs, since it's no longer used for just Linux.

This would also help Servo on FreeBSD work around servo/webrender#4880.