### PR TITLE
Add support for OpenBSD: Use `CLOCK_UPTIME` for awake time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,16 @@ jobs:
       run: cargo test --all --features win10plus
       if: matrix.os == 'windows-latest'
     - run: cargo run --example uptime
+    - name: Test in OpenBSD
+      uses: vmactions/openbsd-vm@ac794a54cc49eef689bb2d9dff6ba77d35483029
+      with:
+        usesh: true
+        prepare: |
+          pkg_add rust
+        run: |
+          cargo test --all
+          cargo run --example uptime
+      if: matrix.os == 'ubuntu-latest'
 
   check_fmt_and_docs:
     name: Checking fmt and docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/badboy/zeitstempel"
 cfg-if = "1.0.0"
 once_cell = "1.5.2"
 
-[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios", target_os = "freebsd"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "openbsd"))'.dependencies]
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ We support the following operating systems:
 * Android
 * iOS
 * FreeBSD
+* OpenBSD
 
 For other operating systems there's a fallback to `std::time::Instant`,
 compared against a process-global fixed reference point.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ cfg_if::cfg_if! {
     if #[cfg(any(target_os = "macos", target_os = "ios"))] {
         mod mac;
         use mac as sys;
-    } else if #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))] {
+    } else if #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "openbsd"))] {
         mod unix;
         use unix as sys;
     } else if #[cfg(all(windows, feature = "win10plus"))] {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -38,7 +38,7 @@ pub fn now_awake() -> u64 {
     };
     #[cfg(any(target_os = "linux", target_os = "android"))]
     let clock = libc::CLOCK_MONOTONIC;
-    #[cfg(target_os = "freebsd")]
+    #[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
     let clock = libc::CLOCK_UPTIME;
     unsafe {
         libc::clock_gettime(clock, &mut ts);


### PR DESCRIPTION
This is the same as FreeBSD.