### PR TITLE
unix: Fix compilation on time64 systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ cfg-if = "1.0.0"
 once_cell = "1.5.2"
 
 [target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "openbsd"))'.dependencies]
-libc = "0.2"
+libc = "0.2.183"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["profileapi", "realtimeapiset"] }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -12,10 +12,7 @@ fn timespec_to_ns(ts: libc::timespec) -> u64 {
 ///
 /// [`clock_gettime`]: https://manpages.debian.org/buster/manpages-dev/clock_gettime.3.en.html
 pub fn now_including_suspend() -> u64 {
-    let mut ts = libc::timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
+    let mut ts = libc::timespec::default();
     unsafe {
         libc::clock_gettime(libc::CLOCK_BOOTTIME, &mut ts);
     }
@@ -32,10 +29,7 @@ pub fn now_including_suspend() -> u64 {
 /// [`clock_gettime`]: https://manpages.debian.org/buster/manpages-dev/clock_gettime.3.en.html
 /// [`FreeBSD clock_gettime`]: https://man.freebsd.org/cgi/man.cgi?query=clock_gettime&manpath=FreeBSD+15.0-RELEASE
 pub fn now_awake() -> u64 {
-    let mut ts = libc::timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
+    let mut ts = libc::timespec::default();
     #[cfg(any(target_os = "linux", target_os = "android"))]
     let clock = libc::CLOCK_MONOTONIC;
     #[cfg(any(target_os = "freebsd", target_os = "openbsd"))]


### PR DESCRIPTION
With time64 enabled in the libc crate, the timespec struct has private padding fields. Therefore, we cannot use normal struct initialization anymore, otherwise it will fail to compile. Instead, it implements Default since 0.2.183, which we can just use instead.

To reproduce:

```rs
$ export RUST_LIBC_UNSTABLE_MUSL_V1_2_3=1
$ cargo check --target armv7-unknown-linux-musleabihf -Zbuild-std=core,alloc,std
[...]
error: cannot construct `timespec` with struct literal syntax due to private fields
  --> src/unix.rs:15:18
   |
15 |     let mut ts = libc::timespec {
   |                  ^^^^^^^^^^^^^^
   |
   = note: ...and other private field `__pad0` that was not provided
help: consider using the `Default` trait
   |
15 -     let mut ts = libc::timespec {
16 -         tv_sec: 0,
17 -         tv_nsec: 0,
18 -     };
15 +     let mut ts = <libc::timespec as std::default::Default>::default();
   |
```